### PR TITLE
Update README to remove M5 Macs fan speed note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Controls fan speed using a privileged helper for secure SMC write access
 
 ## Supported platforms
 - macOS 14+
-- Fan speed is not adjustable on M5 Macs currently
 
 ## Build
 


### PR DESCRIPTION
Remove note about fan speed adjustment on M5 Macs.