### PR TITLE
Add link to CoreSMC library in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Controls fan speed using a privileged helper for secure SMC write access
 
 ## Build
 
-Requires Xcode 26.4+ and access to a private CoreSMC library
+Requires Xcode 26.4+ and access to the private [CoreSMC](https://github.com/TopScrech/CoreSMC?tab=readme-ov-file) library
 
 `iSMC` is bundled from `Vendor/iSMC/iSMC`, so users do not need to install it separately
 


### PR DESCRIPTION
Updated the build requirements to include a link to the CoreSMC library.